### PR TITLE
Ignore active layer and update dependencies

### DIFF
--- a/.github/workflows/test-and-pre-release.yml
+++ b/.github/workflows/test-and-pre-release.yml
@@ -34,7 +34,7 @@ jobs:
         run: >
           docker run --rm --net=host --volume `pwd`:/app -w=/app -e QGIS_PLUGIN_IN_CI=1 qgis/qgis:${{ matrix.docker_tags }} sh -c
           "pip3 install -qr requirements-dev.txt && xvfb-run -s '+extension GLX -screen 0 1024x768x24'
-          pytest -v --cov=pickLayer --cov-report=xml"
+          pytest -v --cov=pickLayer --cov-report=xml test"
 
       # Upload coverage report. Will not work if the repo is private
       - name: Upload coverage to Codecov
@@ -66,7 +66,7 @@ jobs:
           $env:PATH="C:\Program Files\QGIS 3.16\bin;$env:PATH"
           $env:QGIS_PLUGIN_IN_CI=1
           python-qgis-ltr.bat -m pip install -qr requirements-dev.txt
-          python-qgis-ltr.bat -m pytest -v
+          python-qgis-ltr.bat -m pytest -v test
 
   pre-release:
     name: "Pre Release"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,4 +28,4 @@ repos:
           - flake8-bugbear~=21.4.3
           - pep8-naming~=0.11.1
           - flake8-annotations~=2.6.2
-          - flake8-qgis>=0.1.3
+          - flake8-qgis==1.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          - flake8-bugbear~=21.4.3
-          - pep8-naming~=0.11.1
-          - flake8-annotations~=2.6.2
+          - flake8-bugbear==21.4.3
+          - pep8-naming==0.11.1
+          - flake8-annotations==2.6.2
           - flake8-qgis==1.0.0

--- a/pickLayer/core/picklayer.py
+++ b/pickLayer/core/picklayer.py
@@ -454,7 +454,7 @@ class PickLayer:
         highlight.setColor(QtGui.QColor("#36AF6C"))
         highlight.setFillColor(QtGui.QColor("#36AF6C"))
         highlight.setWidth(2)
-        highlight.setToGeometry(geometry, iface.mapCanvas().currentLayer())
+        highlight.setToGeometry(geometry, self.selected_layer)
         process_events()
         sleep(0.1)
         highlight.hide()

--- a/pickLayer/plugin.py
+++ b/pickLayer/plugin.py
@@ -52,7 +52,7 @@ class Plugin:
             pass
 
         self.actions: List[QAction] = []
-        self.menu = tr(plugin_name())
+        self.menu = "&pick layer"
         self.pick_layer: Optional[PickLayer] = None
         self.pick_layer_action: Optional[QAction] = None
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,9 @@
-pre-commit>=2.12.1
-pytest~=6.2.3
+pre-commit==2.15.0
+pytest==6.2.5
 pytest-qt==3.3.0
 pytest-mock==3.6.1
 pytest-cov==2.12.1
+pytest-qgis==1.1.1
 
 # libraries that pre-commit uses
 mypy==0.812
@@ -11,4 +12,4 @@ flake8==3.9.1
 flake8-bugbear~=21.4.3
 pep8-naming~=0.11.1
 flake8-annotations~=2.6.2
-flake8-qgis>=0.1.3
+flake8-qgis==1.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ pytest-qgis==1.1.1
 mypy==0.812
 black==20.8b1
 flake8==3.9.1
-flake8-bugbear~=21.4.3
-pep8-naming~=0.11.1
-flake8-annotations~=2.6.2
+flake8-bugbear==21.4.3
+pep8-naming==0.11.1
+flake8-annotations==2.6.2
 flake8-qgis==1.0.0

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,50 +3,10 @@
 """
 This class contains fixtures and common helper function to keep the test files shorter
 """
-from typing import Tuple
 
 import pytest
-from PyQt5.QtWidgets import QWidget
-from qgis.core import QgsApplication
-from qgis.gui import QgsMapCanvas
 
-from pickLayer.qgis_plugin_tools.testing.qgis_interface import QgisInterface
-from pickLayer.qgis_plugin_tools.testing.utilities import get_qgis_app
 from pickLayer.qgis_plugin_tools.tools.messages import MsgBar
-
-
-@pytest.fixture(autouse=True, scope="session")
-def initialize_qgis() -> Tuple[QgsApplication, QgsMapCanvas, QgisInterface, QWidget]:
-    """Initializes qgis session for all tests"""
-    yield get_qgis_app()
-
-
-@pytest.fixture(scope="session")
-def qgis_app(initialize_qgis) -> QgsApplication:
-    return initialize_qgis[0]
-
-
-@pytest.fixture(scope="session")
-def canvas(initialize_qgis) -> QgsMapCanvas:
-    return initialize_qgis[1]
-
-
-@pytest.fixture(scope="session")
-def iface(initialize_qgis) -> QgisInterface:
-    return initialize_qgis[2]
-
-
-@pytest.fixture(scope="session")
-def qgis_parent(initialize_qgis) -> QWidget:
-    return initialize_qgis[3]
-
-
-@pytest.fixture(scope="function")
-def new_project(iface) -> None:
-    """
-    Initializes new QGIS project by removing layers and relations etc.
-    """
-    yield iface.newProject()
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR:
- Ignores active layer when picking features from a map (fixes #5)
- Allows using "p" as a shortcut button. This was regression compared to previous version (fixes #4)
- Updates test dependencies and qgis_plugin_tools