### PR TITLE
fix: identify features using layer order from search_layer_ids parameter in set active layer tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix layer order in set active layer tool
+
 ## [3.9.4] - 2023-02-08
 
 - fix plugin packaging

--- a/pickLayer/core/set_active_layer_tool.py
+++ b/pickLayer/core/set_active_layer_tool.py
@@ -53,7 +53,7 @@ class SetActiveLayerTool(QgsMapToolIdentify):
     from multiple layers the active layer is selected from the first
     identify result. Identify results are in same order as
     the search_layer_ids parameter. If search_layer_ids is empty then the
-    result list order is in same order as QgsProject.instance().mapLayers().
+    result list is in same order as iface.mapCanvas().layers().
 
     Map tool is automatically deactived and swapped to previous map tool
     after the new active layer is set.
@@ -103,14 +103,12 @@ class SetActiveLayerTool(QgsMapToolIdentify):
     def _get_identify_results(
         self, location: QgsPointXY, search_layer_ids: Optional[List[str]] = None
     ) -> List[QgsMapToolIdentify.IdentifyResult]:
+        layers = []
         if search_layer_ids:
-            layers = []
             for layer_id in search_layer_ids:
                 layer = QgsProject.instance().mapLayer(layer_id)
                 if isinstance(layer, QgsVectorLayer):
                     layers.append(layer)
-        else:
-            layers = QgsProject.instance().mapLayers().values()
 
         if len(layers) > 0:
             return self.identify(

--- a/test/unit/test_set_active_layer_tool.py
+++ b/test/unit/test_set_active_layer_tool.py
@@ -182,6 +182,18 @@ def test_set_active_layer_using_closest_feature_with_search_layers(
     identify_results = m_choose_layer_from_identify_results.call_args.args[0]
     assert len(identify_results) == expected_num_results
 
+    # check that identify results are in same order
+    # as requested layer ids (result may contain multiple
+    # features from one layer)
+    identify_results_layer_ids = []
+    previous_id = ""
+    for result in identify_results:
+        if result.mLayer.id() != previous_id:
+            identify_results_layer_ids.append(result.mLayer.id())
+        previous_id = result.mLayer.id()
+
+    assert identify_results_layer_ids == layer_ids
+
 
 def test_set_active_layer_using_closest_feature_with_search_layers_set_to_none_should_find_all(
     map_tool,


### PR DESCRIPTION

## Description <!-- markdownlint-disable-line MD041 -->

 identify features using layer order from search_layer_ids parameter in set active layer tool

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Other

- [ ] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [X] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/pickLayer/blob/main/CHANGELOG.md
