### PR TITLE
Find most logical closest feature

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,3 +38,7 @@ pickLayer=
     **/*.ts
     **/*.qm
     **/*.ui
+
+[options.entry_points]
+qgis_plugin_tools =
+    pickLayer = pickLayer


### PR DESCRIPTION
There is a bug with setting active layer where from multiple nested features the top one is selected always.

This PR:
- Calculates centroid of the features in order to find the most logical one of the closest feature
