### PR TITLE
fix: use self.search_layer_ids again

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     rev: v0.0.292
     hooks:
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+        args: [--fix, --exit-non-zero-on-fix, --extend-fixable=F401]
   - repo: https://github.com/psf/black
     rev: 23.7.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix defining layers to search from for set active layer tool
+
 ## [3.9.9] - 2023-11-01
 
 - Find most logical closest feature from nested features with set active layer tool

--- a/pickLayer/core/set_active_layer_tool.py
+++ b/pickLayer/core/set_active_layer_tool.py
@@ -100,9 +100,10 @@ class SetActiveLayerTool(QgsMapToolIdentify):
     def _get_identify_results(
         self, location: QgsPointXY, search_layer_ids: Optional[list[str]] = None
     ) -> list[QgsMapToolIdentify.IdentifyResult]:
+        layer_ids = search_layer_ids or self.search_layer_ids or []
         layers = []
-        if search_layer_ids:
-            for layer_id in search_layer_ids:
+        if layer_ids:
+            for layer_id in layer_ids:
                 layer = QgsProject.instance().mapLayer(layer_id)
                 if isinstance(layer, QgsVectorLayer):
                     layers.append(layer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,11 @@ ignore = [
     ]
 line-length = 88
 
+unfixable = [
+    "F401", # Unused imports
+    "F841", # Unused variables
+]
+
 # List of all rules https://docs.astral.sh/ruff/rules/
 select = [
     "ANN", # flake8-annotations

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -5,7 +5,7 @@ pytest==6.2.5
 pytest-qt==3.3.0
 pytest-mock==3.7.0
 pytest-cov==2.12.1
-pytest-qgis==1.3.1
+pytest-qgis==1.3.5
 
 #stubs
 pyqt5-stubs==5.15.6.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -85,7 +85,7 @@ pytest-cov==2.12.1
     # via -r requirements-dev.in
 pytest-mock==3.7.0
     # via -r requirements-dev.in
-pytest-qgis==1.3.1
+pytest-qgis==1.3.5
     # via -r requirements-dev.in
 pytest-qt==3.3.0
     # via -r requirements-dev.in

--- a/test/unit/test_set_active_layer_tool.py
+++ b/test/unit/test_set_active_layer_tool.py
@@ -30,10 +30,11 @@ from qgis.core import (
     QgsPointXY,
     QgsProject,
     QgsRasterLayer,
+    QgsRectangle,
     QgsVectorLayer,
     QgsVectorLayerUtils,
 )
-from qgis.gui import QgsMapTool, QgsMapToolIdentify
+from qgis.gui import QgsMapTool
 from qgis_plugin_tools.tools.resources import plugin_test_data_path
 
 from pickLayer.core.set_active_layer_tool import SetActiveLayerTool
@@ -42,11 +43,9 @@ from pickLayer.definitions.settings import Settings
 MOUSE_LOCATION = QgsPointXY(0, 0)
 
 
-def create_identify_result(
+def create_identify_layers(
     identified_feature_geom_wtks: list[tuple[str, str, str]]
-) -> list[QgsMapToolIdentify.IdentifyResult]:
-    results = []
-
+) -> None:
     for wkt, crs, layer_name in identified_feature_geom_wtks:
         geometry = QgsGeometry.fromWkt(wkt)
         layer = QgsMemoryProviderUtils.createMemoryLayer(
@@ -57,22 +56,15 @@ def create_identify_result(
         )
         feature = QgsVectorLayerUtils.createFeature(layer, geometry, {})
         layer.dataProvider().addFeature(feature)
-
-        # using the actual QgsMapToolIdentify.IdentifyResult causes
-        # fatal exceptions, mock probably is sufficient for testing
-        results.append(
-            MagicMock(**{"mLayer": layer, "mFeature": feature})  # noqa: PIE804
-        )
-
-    return results
+        QgsProject.instance().addMapLayer(layer)
 
 
 @pytest.fixture()
-def map_tool(qgis_iface):
+def map_tool(qgis_iface, qgis_new_project):
     return SetActiveLayerTool(qgis_iface.mapCanvas())
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def test_layers():
     layers = [
         QgsVectorLayer("PointZ", "point_layer", "memory"),
@@ -342,7 +334,7 @@ def test_preferred_type_chosen_from_different_types(
     mocker: MockerFixture,
     qgis_iface: QgisInterface,
 ):
-    results = create_identify_result(
+    create_identify_layers(
         [
             ("POINT(3 3)", "EPSG:3067", "point"),
             ("LINESTRING(4 4, 5 5)", "EPSG:3067", "line"),
@@ -351,8 +343,6 @@ def test_preferred_type_chosen_from_different_types(
     )
 
     QgsProject.instance().setCrs(QgsCoordinateReferenceSystem("EPSG:3067"))
-
-    mocker.patch.object(map_tool, "identify", return_value=results)
 
     m_set_active_layer = mocker.patch.object(
         qgis_iface, "setActiveLayer", return_value=None
@@ -372,7 +362,7 @@ def test_closest_of_same_type_chosen(
     mocker: MockerFixture,
     qgis_iface: QgisInterface,
 ):
-    results = create_identify_result(
+    create_identify_layers(
         [
             ("POINT(3 3)", "EPSG:3067", "point-mid"),
             ("POINT(2 2)", "EPSG:3067", "point-close"),
@@ -382,8 +372,6 @@ def test_closest_of_same_type_chosen(
 
     QgsProject.instance().setCrs(QgsCoordinateReferenceSystem("EPSG:3067"))
     map_tool.canvas().setDestinationCrs(QgsCoordinateReferenceSystem("EPSG:3067"))
-
-    mocker.patch.object(map_tool, "identify", return_value=results)
 
     m_set_active_layer = mocker.patch.object(
         qgis_iface, "setActiveLayer", return_value=None
@@ -404,19 +392,32 @@ def test_closest_of_same_type_chosen_even_if_project_and_layer_crs_differs(
     qgis_iface: QgisInterface,
     qgis_new_project,
 ):
-    results = create_identify_result(
+    Settings.search_radius.set(2)
+    create_identify_layers(
         [
             # points close to 250000,6700000 in 3067 in different crs's
-            ("POINT(22.46220271 60.35440884)", "EPSG:4326", "point-far"),
-            ("POINT(2415468 6694753)", "EPSG:2392", "point-mid"),
-            ("POINT(2501177 8479351)", "EPSG:3857", "point-close"),
+            (
+                "POINT(22.46220271 60.35440884)",
+                "EPSG:4326",
+                "point-far",
+            ),
+            (
+                "POINT(2415468 6694753)",
+                "EPSG:2392",
+                "point-mid",
+            ),
+            (
+                "POINT(2501177 8479351)",
+                "EPSG:3857",
+                "point-close",
+            ),
         ]
     )
 
     QgsProject.instance().setCrs(QgsCoordinateReferenceSystem("EPSG:3067"))
     map_tool.canvas().setDestinationCrs(QgsCoordinateReferenceSystem("EPSG:3067"))
-
-    mocker.patch.object(map_tool, "identify", return_value=results)
+    map_tool.canvas().setExtent(QgsRectangle(249900, 6699000, 250100, 6701000))
+    map_tool.canvas().refreshAllLayers()
 
     m_set_active_layer = mocker.patch.object(
         qgis_iface, "setActiveLayer", return_value=None
@@ -437,7 +438,7 @@ def test_line_crossing_origin_chosen_as_closest(
     qgis_iface: QgisInterface,
     qgis_new_project,
 ):
-    results = create_identify_result(
+    create_identify_layers(
         [
             ("LINESTRING(1.1 1.1, 2 2)", "EPSG:3067", "line-not-crossing"),
             ("LINESTRING(0 2, 2 0)", "EPSG:3067", "line-crossing"),
@@ -446,8 +447,6 @@ def test_line_crossing_origin_chosen_as_closest(
 
     QgsProject.instance().setCrs(QgsCoordinateReferenceSystem("EPSG:3067"))
     map_tool.canvas().setDestinationCrs(QgsCoordinateReferenceSystem("EPSG:3067"))
-
-    mocker.patch.object(map_tool, "identify", return_value=results)
 
     m_set_active_layer = mocker.patch.object(
         qgis_iface, "setActiveLayer", return_value=None
@@ -468,7 +467,7 @@ def test_top_polygon_chosen_from_multiple_nested_even_if_top_not_closest(
     qgis_iface: QgisInterface,
     qgis_new_project,
 ):
-    results = create_identify_result(
+    create_identify_layers(
         [
             ("POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))", "EPSG:3067", "polygon-0-10"),
             ("POLYGON((0 -5, 0 5, 5 5, 5 -5, 0 -5))", "EPSG:3067", "polygon-5-5"),
@@ -477,8 +476,6 @@ def test_top_polygon_chosen_from_multiple_nested_even_if_top_not_closest(
 
     QgsProject.instance().setCrs(QgsCoordinateReferenceSystem("EPSG:3067"))
     map_tool.canvas().setDestinationCrs(QgsCoordinateReferenceSystem("EPSG:3067"))
-
-    mocker.patch.object(map_tool, "identify", return_value=results)
 
     m_set_active_layer = mocker.patch.object(
         qgis_iface, "setActiveLayer", return_value=None
@@ -500,7 +497,7 @@ def test_bottom_polygon_chosen_from_multiple_nested_when_bottom_closest(
     qgis_iface: QgisInterface,
     qgis_new_project,
 ):
-    results = create_identify_result(
+    create_identify_layers(
         [
             ("POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))", "EPSG:3067", "polygon-0-10"),
             ("POLYGON((3 3, 3 5, 5 5, 5 3, 3 3))", "EPSG:3067", "polygon-3-5"),
@@ -509,8 +506,6 @@ def test_bottom_polygon_chosen_from_multiple_nested_when_bottom_closest(
 
     QgsProject.instance().setCrs(QgsCoordinateReferenceSystem("EPSG:3067"))
     map_tool.canvas().setDestinationCrs(QgsCoordinateReferenceSystem("EPSG:3067"))
-
-    mocker.patch.object(map_tool, "identify", return_value=results)
 
     m_set_active_layer = mocker.patch.object(
         qgis_iface, "setActiveLayer", return_value=None


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

This PR:
- Re-enables internal search_layer_ids in set active layer tool
- Uses real identify in tests instead of mocked one. pytest-qgis==1.3.5 gets rid of fatal exceptions on Windows
- Adjust ruff autofix behaviour

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

- [x] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [x] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/pickLayer/blob/main/CHANGELOG.md
