### PR TITLE
chore: release plugin to pypi as well

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,22 @@ on:
     types: released
 
 jobs:
+  pypi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+      - run: |
+          pip install build
+      - run: |
+          python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
   plugin_dst:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Release plugin to pypi as well for easier access for other plugins
+
 ## [3.9.10] - 2023-11-02
 
 - Fix defining layers to search from for set active layer tool


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

This PR adds release job to publish the plugin to PyPI. The main reason for this is to help developing other plugins that use pickLayer internally.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

- [x] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [x] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/pickLayer/blob/main/CHANGELOG.md
