### PR TITLE
Upgrade plugin tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Upgrade qgis_plugin_tools to version that supports subplugins
+
 ## [3.9.11] - 2023-11-03
 
 - Release plugin to pypi as well for easier access for other plugins

--- a/picklayer.code-workspace
+++ b/picklayer.code-workspace
@@ -29,8 +29,8 @@
         "[python]": {
             "editor.formatOnSave": true,
             "editor.codeActionsOnSave": {
-                "source.organizeImports.ruff": true,
-                "source.fixAll": true
+                "source.organizeImports.ruff": "explicit",
+                "source.fixAll": "explicit"
             },
             "editor.defaultFormatter": "ms-python.black-formatter",
         },

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ python-dotenv==1.0.0
     # via qgis-plugin-dev-tools
 qgis-plugin-dev-tools==0.5.0
     # via -r requirements.in
-qgis-plugin-tools==0.2.0
+qgis-plugin-tools==0.4.0
     # via picklayer
 requests==2.28.1
     # via qgis-plugin-dev-tools

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ packages =
     pickLayer.ui
     pickLayer.resources
 install_requires =
-    qgis_plugin_tools>=0.2.0
+    qgis_plugin_tools>=0.4.0
 
 [options.package_data]
 pickLayer=

--- a/test/ui/test_settings_dialog.py
+++ b/test/ui/test_settings_dialog.py
@@ -16,6 +16,8 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with PickLayer. If not, see <https://www.gnu.org/licenses/>.
+from unittest import mock
+
 import pytest
 from qgis_plugin_tools.tools.custom_logging import (
     LogTarget,
@@ -28,14 +30,18 @@ from pickLayer.definitions.settings import Settings
 from pickLayer.ui.settings_dialog import SettingsDialog
 
 ORIGINAL_RADIUS = 1.5
+PLUGIN_NAME = "pickLayer"
 
 
 @pytest.fixture()
 def settings_dialog(_initialize_ui, qtbot):
     # Setup
     Settings.search_radius.set(ORIGINAL_RADIUS)
-    set_setting(get_log_level_key(LogTarget.FILE), "INFO")
-    set_setting(get_log_level_key(LogTarget.STREAM), "INFO")
+    with mock.patch(
+        "qgis_plugin_tools.tools.settings.plugin_name", return_value=PLUGIN_NAME
+    ):
+        set_setting(get_log_level_key(LogTarget.FILE), "INFO")
+        set_setting(get_log_level_key(LogTarget.STREAM), "INFO")
 
     settings_dialog = SettingsDialog()
     settings_dialog.show()
@@ -53,11 +59,17 @@ def test_set_file_log_level(settings_dialog, qtbot):
     qtbot.mouseMove(settings_dialog.combo_box_log_level_file)
     qtbot.keyClicks(settings_dialog.combo_box_log_level_file, "D")
 
-    assert get_log_level_name(LogTarget.FILE) == "DEBUG"
+    with mock.patch(
+        "qgis_plugin_tools.tools.settings.plugin_name", return_value=PLUGIN_NAME
+    ):
+        assert get_log_level_name(LogTarget.FILE) == "DEBUG"
 
 
 def test_set_console_log_level(settings_dialog, qtbot):
     qtbot.mouseMove(settings_dialog.combo_box_log_level_console)
     qtbot.keyClicks(settings_dialog.combo_box_log_level_console, "E")
 
-    assert get_log_level_name(LogTarget.STREAM) == "ERROR"
+    with mock.patch(
+        "qgis_plugin_tools.tools.settings.plugin_name", return_value=PLUGIN_NAME
+    ):
+        assert get_log_level_name(LogTarget.STREAM) == "ERROR"


### PR DESCRIPTION
## Description

Upgrade `qgis-plugin-tool` to 0.4.0. This upgrade supports the usage as a subplugin.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

- [x] Non-breaking change
- [ ] Breaking change

## Developer checklist

- [x] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/pickLayer/blob/main/CHANGELOG.md
